### PR TITLE
Backend & Frontend javascript implementation of student/instructor tags.

### DIFF
--- a/src/posts/user.js
+++ b/src/posts/user.js
@@ -104,7 +104,7 @@ module.exports = function (Posts) {
             'uid', 'username', 'fullname', 'userslug',
             'reputation', 'postcount', 'topiccount', 'picture',
             'signature', 'banned', 'banned:expire', 'status',
-            'lastonline', 'groupTitle', 'mutedUntil', 'accounttype'
+            'lastonline', 'groupTitle', 'mutedUntil', 'accounttype',
         ];
         const result = await plugins.hooks.fire('filter:posts.addUserFields', {
             fields: fields,

--- a/src/posts/user.js
+++ b/src/posts/user.js
@@ -104,7 +104,7 @@ module.exports = function (Posts) {
             'uid', 'username', 'fullname', 'userslug',
             'reputation', 'postcount', 'topiccount', 'picture',
             'signature', 'banned', 'banned:expire', 'status',
-            'lastonline', 'groupTitle', 'mutedUntil',
+            'lastonline', 'groupTitle', 'mutedUntil', 'accounttype'
         ];
         const result = await plugins.hooks.fire('filter:posts.addUserFields', {
             fields: fields,

--- a/src/user/create.js
+++ b/src/user/create.js
@@ -51,7 +51,7 @@ module.exports = function (User) {
         let userData = {
             username: data.username,
             userslug: data.userslug,
-            accounttype: data.accounttype || 'student', // tag only works if student option chosen
+            accounttype: data['account-type'] || 'student',
             email: data.email || '',
             joindate: timestamp,
             lastonline: timestamp,

--- a/src/user/create.js
+++ b/src/user/create.js
@@ -51,7 +51,7 @@ module.exports = function (User) {
         let userData = {
             username: data.username,
             userslug: data.userslug,
-            accounttype: data.accounttype,  // tag only works if student option chosen
+            accounttype: data.accounttype || 'student',  // tag only works if student option chosen
             email: data.email || '',
             joindate: timestamp,
             lastonline: timestamp,

--- a/src/user/create.js
+++ b/src/user/create.js
@@ -88,6 +88,7 @@ module.exports = function (User) {
         const bulkAdd = [
             ['username:uid', userData.uid, userData.username],
             [`user:${userData.uid}:usernames`, timestamp, `${userData.username}:${timestamp}`],
+            ['accounttype:uid', userData.uid, userData.accounttype],
             ['username:sorted', 0, `${userData.username.toLowerCase()}:${userData.uid}`],
             ['userslug:uid', userData.uid, userData.userslug],
             ['users:joindate', timestamp, userData.uid],

--- a/src/user/create.js
+++ b/src/user/create.js
@@ -16,11 +16,11 @@ module.exports = function (User) {
         data.username = data.username.trim();
         data.userslug = slugify(data.username);
         if (data.email !== undefined) {
-            console.log(data.email)
+            console.log(data.email);
             data.email = String(data.email).trim();
         }
         if (data.accounttype !== undefined) {
-            console.log(data.accounttype)
+            console.log(data.accounttype);
             data.accounttype = data.accounttype.trim();
         }
 
@@ -51,7 +51,7 @@ module.exports = function (User) {
         let userData = {
             username: data.username,
             userslug: data.userslug,
-            accounttype: data.accounttype || 'student',  // tag only works if student option chosen
+            accounttype: data.accounttype || 'student', // tag only works if student option chosen
             email: data.email || '',
             joindate: timestamp,
             lastonline: timestamp,

--- a/src/user/create.js
+++ b/src/user/create.js
@@ -16,12 +16,10 @@ module.exports = function (User) {
         data.username = data.username.trim();
         data.userslug = slugify(data.username);
         if (data.email !== undefined) {
-            console.log(data.email);
             data.email = String(data.email).trim();
         }
-        if (data.accounttype !== undefined) {
-            console.log(data.accounttype);
-            data.accounttype = data.accounttype.trim();
+        if (data['account-type'] !== undefined) {
+            data.accounttype = data['account-type'].trim();
         }
 
         await User.isDataValid(data);

--- a/src/user/create.js
+++ b/src/user/create.js
@@ -16,9 +16,11 @@ module.exports = function (User) {
         data.username = data.username.trim();
         data.userslug = slugify(data.username);
         if (data.email !== undefined) {
+            console.log(data.email)
             data.email = String(data.email).trim();
         }
         if (data.accounttype !== undefined) {
+            console.log(data.accounttype)
             data.accounttype = data.accounttype.trim();
         }
 
@@ -49,7 +51,7 @@ module.exports = function (User) {
         let userData = {
             username: data.username,
             userslug: data.userslug,
-            accounttype: data.accounttype || 'student',
+            accounttype: data.accounttype,  // tag only works if student option chosen
             email: data.email || '',
             joindate: timestamp,
             lastonline: timestamp,

--- a/src/user/delete.js
+++ b/src/user/delete.js
@@ -129,6 +129,7 @@ module.exports = function (User) {
             ['username:sorted', `${userData.username.toLowerCase()}:${uid}`],
             ['userslug:uid', userData.userslug],
             ['fullname:uid', userData.fullname],
+            ['accounttype:uid', userData.accounttype],
         ];
         if (userData.email) {
             bulkRemove.push(['email:uid', userData.email.toLowerCase()]);

--- a/themes/nodebb-theme-persona/templates/partials/topic/post.tpl
+++ b/themes/nodebb-theme-persona/templates/partials/topic/post.tpl
@@ -8,7 +8,7 @@
 
     <small class="pull-left">
         <strong>
-            <a href="<!-- IF posts.user.userslug -->{config.relative_path}/user/{posts.user.userslug}<!-- ELSE -->#<!-- ENDIF posts.user.userslug -->" itemprop="author" data-username="{posts.user.username}" data-uid="{posts.user.uid}">{posts.user.displayname}</a>
+            <a href="<!-- IF posts.user.userslug -->{config.relative_path}/user/{posts.user.userslug}<!-- ELSE -->#<!-- ENDIF posts.user.userslug -->" itemprop="author" data-username="{posts.user.username}" data-type="{posts.user.accounttype}" data-uid="{posts.user.uid}">{posts.user.displayname} | {posts.user.accounttype}</a>
         </strong>
 
         <!-- IMPORT partials/topic/badge.tpl -->


### PR DESCRIPTION
[FRONTEND] Enables account type tag to be displayed on topics discussion board on NodeBB by modifying `themes/nodebb-theme-persona/templates/partials/topic/post.tpl` file.

[BACKEND] Added account type as visible metadata tag to userData when user is created and when a post is created by a specified user in `src/posts/user.js` and `src/user/create.js`. Explicitly created link between user ID and account type to be added to `db` when account is registered and removed when account is deleted.

User can now:
- Post and reply with their account types displayed next to their username, allowing class community to distinguish between peer and professor remarks.
<img width="1189" alt="Screen Shot 2023-02-07 at 9 52 40 PM" src="https://user-images.githubusercontent.com/73270781/217416690-d38f05b0-fe65-4a00-bdb4-d8f22e9fc2be.png">
- Delete their account along with their past account type.

Resolves #7. Resolves #8 .