### PR TITLE
Added checkbox on posts so that users can mark them as resolved or unresolved

### DIFF
--- a/public/src/client/topic.js
+++ b/public/src/client/topic.js
@@ -64,7 +64,7 @@ define('forum/topic', [
         addPostsPreviewHandler();
 
         handleBookmark(tid);
-
+        addResolved();
         $(window).on('scroll', utils.debounce(updateTopicTitle, 250));
 
         handleTopicSearch();
@@ -178,6 +178,12 @@ define('forum/topic', [
                 navigator.scrollToIndex(toPost.attr('data-index'), true);
                 return false;
             }
+        });
+    }
+
+    function addResolved() {
+        components.get('topic/resolved').on('click', function () {
+            socket.emit('topics.setResolved', { tid: tid });
         });
     }
 

--- a/src/socket.io/topics.js
+++ b/src/socket.io/topics.js
@@ -125,4 +125,8 @@ SocketTopics.getPostCountInTopic = async function (socket, tid) {
     return await db.sortedSetScore(`tid:${tid}:posters`, socket.uid);
 };
 
+SocketTopics.setResolved = async function (socket, data) {
+    await topics.setResolved(data.tid);
+};
+
 require('../promisify')(SocketTopics);

--- a/src/topics/index.js
+++ b/src/topics/index.js
@@ -33,6 +33,8 @@ require('./tools')(Topics);
 Topics.thumbs = require('./thumbs');
 require('./bookmarks')(Topics);
 require('./merge')(Topics);
+// 313: added resolved into Topics
+require('./resolved')(Topics);
 Topics.events = require('./events');
 
 Topics.exists = async function (tids) {

--- a/src/topics/resolved.js
+++ b/src/topics/resolved.js
@@ -1,0 +1,23 @@
+"use strict";
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
+const db = require("../database");
+module.exports = function (Topics) {
+    Topics.setResolved = function (tid) {
+        return __awaiter(this, void 0, void 0, function* () {
+            // The next line calls a function in a module that has not been updated to TS yet
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
+            const resolved = (yield db.getObjectField(`topic:${tid}`, 'resolved')) === 'true';
+            // The next line calls a function in a module that has not been updated to TS yet
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
+            yield db.setObjectField(`topic:${tid}`, 'resolved', !resolved);
+        });
+    };
+};

--- a/src/topics/resolved.ts
+++ b/src/topics/resolved.ts
@@ -1,0 +1,12 @@
+import db = require('../database');
+
+export = function (Topics: { setResolved?: (tid: number) => Promise<void>; }) {
+    Topics.setResolved = async function (tid: number): Promise<void> {
+        // The next line calls a function in a module that has not been updated to TS yet
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
+        const resolved: boolean = (await db.getObjectField(`topic:${tid}`, 'resolved') as string) === 'true';
+        // The next line calls a function in a module that has not been updated to TS yet
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
+        await db.setObjectField(`topic:${tid}`, 'resolved', !resolved);
+    };
+};

--- a/themes/nodebb-theme-persona/templates/topic.tpl
+++ b/themes/nodebb-theme-persona/templates/topic.tpl
@@ -4,7 +4,7 @@
     {{{end}}}
 </div>
 
-<!-- IF !frontEndResolved -->this post is unresolved<!-- ELSE -->this post is resolved<!-- ENDIF !frontEndResolved -->
+
 
 <div class="row">
     <div class="topic <!-- IF widgets.sidebar.length -->col-lg-9 col-sm-12<!-- ELSE -->col-lg-12<!-- ENDIF widgets.sidebar.length -->">
@@ -44,9 +44,17 @@
                 <!-- IMPORT partials/topic/browsing-users.tpl -->
                 </div>
                 {{{ end }}}
-
                 <!-- IMPORT partials/post_bar.tpl -->
             </div>
+            <!-- IF !loggedIn -->This post is resolved.
+            <!-- ELSE -->
+            <div class="resolved">
+                <label class="mdl-switch mdl-js-switch mdl-js-ripple-effect" for="switch-2">
+                    <input component = "topic/resolved" type="checkbox" id="switch-2" class="mdl-switch__input" <!-- IF frontEndResolved -->checked<!-- ENDIF !frontEndResolved -->>
+                    <span class="mdl-switch__label">Resolved?</span>
+                </label>
+            </div>
+            <!-- ENDIF !loggedIn -->
         </div>
         <!-- IF merger -->
         <div component="topic/merged/message" class="alert alert-warning clearfix">


### PR DESCRIPTION
Resolves #4 

Changes:
- Added frontend checkbox that mirrors the resolved status of the topic.
- Added a socket function to modify the topic resolved state. 
- Added public js for the checkbox. 

Testing:
- Passed local lint
- Passed all local tests previously written.