### PR TITLE
Added tests for User Story 2, displaying account type of a user

### DIFF
--- a/src/user/create.ts
+++ b/src/user/create.ts
@@ -189,7 +189,7 @@ export = function (User: TheUser) {
             data.email = String(data.email).trim();
         }
         if (data['account-type'] !== undefined) {
-            data.accounttype = (data['account-type'] as string).trim();
+            data['account-type'] = (data['account-type'] as string).trim();
         }
 
         await User.isDataValid(data);

--- a/test/user.js
+++ b/test/user.js
@@ -581,8 +581,12 @@ describe('User', () => {
             userData['account-type'] = '  instructor ';
             const uid = await User.create(userData);
             assert(await db.isSortedSetMember('accounttype:uid', 'instructor'));
+            // Check that account type field is stored as an singleton object
+            assert(await db.sortedSetCount('accounttype:uid', '-inf', '+inf') === 1);
             await User.deleteAccount(uid);
             assert(!await db.isSortedSetMember('accounttype:uid', 'instructor'));
+            // Assert that once account is deleted, object is now empty
+            assert(await db.sortedSetCount('accounttype:uid', '-inf', '+inf') === 0);
         });
 
         it('should not re-add user to users:postcount if post is purged after user account deletion', async () => {

--- a/test/user.js
+++ b/test/user.js
@@ -580,7 +580,7 @@ describe('User', () => {
             };
             userData['account-type'] = '  instructor ';
             const uid = await User.create(userData);
-            assert(await db.isSortedSetMember('accounttype:uid', uid));
+            assert(await db.isSortedSetMember('accounttype:uid', 'instructor'));
         });
 
         it('should not re-add user to users:postcount if post is purged after user account deletion', async () => {

--- a/test/user.js
+++ b/test/user.js
@@ -184,6 +184,29 @@ describe('User', () => {
             const data = await User.getUserData(uid);
             assert.strictEqual(data.accounttype, 'student');
         });
+
+        it('accounttype should default to student, if not specified', async () => {
+            const inputData = {
+                username: 'itsroro',
+                password: 'hammershark23',
+                email: 'rb@example.com',
+            };
+            const uid = await User.create(inputData);
+            const data = await User.getUserData(uid);
+            assert.strictEqual(data.accounttype, 'student');
+        });
+
+        it('accounttype should store correct field, if specified', async () => {
+            const inputData = {
+                username: 'rb123',
+                password: 'hammershark234',
+                email: 'roba@example.com',
+            };
+            inputData['account-type'] = '     instructor    ';
+            const uid = await User.create(inputData);
+            const data = await User.getUserData(uid);
+            assert.strictEqual(data.accounttype, 'instructor');
+        });
     });
 
     describe('.uniqueUsername()', () => {

--- a/test/user.js
+++ b/test/user.js
@@ -581,6 +581,8 @@ describe('User', () => {
             userData['account-type'] = '  instructor ';
             const uid = await User.create(userData);
             assert(await db.isSortedSetMember('accounttype:uid', 'instructor'));
+            await User.deleteAccount(uid);
+            assert(!await db.isSortedSetMember('accounttype:uid', 'instructor'));
         });
 
         it('should not re-add user to users:postcount if post is purged after user account deletion', async () => {

--- a/test/user.js
+++ b/test/user.js
@@ -572,6 +572,17 @@ describe('User', () => {
             });
         });
 
+        it('should not store accounttype once account is deleted', async () => {
+            const userData = {
+                username: 'anolduser',
+                password: 'AnolDpass',
+                email: 'oops@example.com',
+            };
+            userData['account-type'] = '  instructor ';
+            const uid = await User.create(userData);
+            assert(await db.isSortedSetMember('accounttype:uid', uid));
+        });
+
         it('should not re-add user to users:postcount if post is purged after user account deletion', async () => {
             const uid = await User.create({ username: 'olduserwithposts' });
             assert(await db.isSortedSetMember('users:postcount', uid));

--- a/test/user.js
+++ b/test/user.js
@@ -176,8 +176,8 @@ describe('User', () => {
         it('accounttype should have trailing/preceding spaces removed', async () => {
             const inputData = {
                 username: 'yoitsroro',
-                password: userData.password,
-                email: userData.email,
+                password: 'hammershark',
+                email: 'rohinib@example.com',
             };
             inputData['account-type'] = '     student ';
             const uid = await User.create(inputData);

--- a/test/user.js
+++ b/test/user.js
@@ -172,6 +172,18 @@ describe('User', () => {
             ]);
             assert.strictEqual(err.message, '[[error:email-taken]]');
         });
+
+        it('accounttype should have trailing/preceding spaces removed', async () => {
+            const inputData = {
+                username: 'yoitsroro',
+                password: userData.password,
+                email: userData.email,
+            };
+            inputData['account-type'] = '     student ';
+            const uid = await User.create(inputData);
+            const data = await User.getUserData(uid);
+            assert.strictEqual(data.accounttype, 'student');
+        });
     });
 
     describe('.uniqueUsername()', () => {


### PR DESCRIPTION
Resolves #16 .

Added tests in `test/user.js` covering changes in implementing User Story 1, displaying the account type for a user when they create a post. Specifically tests changes made in PR #10 .

During testing process, learned that account type was stored in a sortedSet singleton object. To test if account deletion occurred as expected, tested object length before and after deletion of this object.

Testing:
* Passed local lint.
* Passed all local tests previously written and new tests.
* Abides by definition of success in Issue #7 .