### PR TITLE
Installed ts-standard tool for static analysis

### DIFF
--- a/install/package.json
+++ b/install/package.json
@@ -198,5 +198,15 @@
             "email": "baris@nodebb.org",
             "url": "https://github.com/barisusakli"
         }
-    ]
+    ],
+    "ts-standard": {
+        "ignore": [
+            "dist",
+            "src/**/*.js",
+            "test/**/*.js",
+            "public/**/*.js",
+            "*.js",
+            "*.cjs"
+        ]
+    }
 }

--- a/install/package.json
+++ b/install/package.json
@@ -170,6 +170,7 @@
         "mockdate": "3.0.5",
         "nyc": "15.1.0",
         "smtp-server": "3.11.0",
+        "ts-standard": "^12.0.2",
         "typescript": "^4.9.4"
     },
     "resolutions": {


### PR DESCRIPTION
Changed `install/package.json` so that ts-standard static analysis tool is installed as a dev tool. Resolves #32 .

To use, run `npx ts-standard` 

Terminal output attached here: 
[ts-standard-output.txt](https://github.com/CMU-313/spring23-nodebb-specs/files/10997272/ts-standard-output.txt)
