### PR TITLE
Fixed ts-standard errors from assigned files in repo 

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -64,6 +64,7 @@ function find_compiled_js() {
                 rules: {
                     "no-use-before-define": "off",
                     "@typescript-eslint/no-use-before-define": "error",
+                    "@typescript-eslint/strict-boolean-expressions": "warn",
                     "indent": ["error", 2],
                     "semi": ["error", "never"],
                     "comma-dangle": ["error", "never"],

--- a/.github/workflows/ts-standard.yaml
+++ b/.github/workflows/ts-standard.yaml
@@ -1,0 +1,83 @@
+name: TS Standard
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+defaults:
+  run:
+    shell: bash
+
+permissions:
+  contents: read
+
+jobs:
+  lint:
+    permissions:
+      checks: write  # for coverallsapp/github-action to create new checks
+      contents: read  # for actions/checkout to fetch code
+    name: Lint
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest]
+        node: [16]
+    runs-on: ${{ matrix.os }}
+    env:
+      TEST_ENV: ${{ matrix.test_env || 'production' }}
+
+    services:
+      mongo:
+        image: 'mongo:3.7'
+        ports:
+          # Maps port 27017 on service container to the host
+          - 27017:27017
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - run: cp install/package.json package.json
+
+      - name: Install Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ matrix.node }}
+
+      - name: NPM Install
+        uses: bahmutov/npm-install@v1
+        with:
+          useLockFile: false
+
+      - name: Setup on MongoDB
+        env:
+          SETUP: >-
+            {
+              "url": "http://127.0.0.1:4567",
+              "secret": "abcdef",
+              "admin:username": "admin",
+              "admin:email": "test@example.org",
+              "admin:password": "hAN3Eg8W",
+              "admin:password:confirm": "hAN3Eg8W",
+
+              "database": "mongo",
+              "mongo:host": "127.0.0.1",
+              "mongo:port": 27017,
+              "mongo:username": "",
+              "mongo:password": "",
+              "mongo:database": "nodebb"
+            }
+          CI: >-
+            {
+              "host": "127.0.0.1",
+              "port": 27017,
+              "database": "ci_test"
+            }
+        run: |
+          node app --setup="${SETUP}" --ci="${CI}"
+
+      - name: Run ts-standard
+        run: npm run ts-standard

--- a/install/package.json
+++ b/install/package.json
@@ -12,7 +12,7 @@
     "scripts": {
         "start": "npx tsc && node loader.js",
         "lint": "npx tsc && eslint --cache ./nodebb .",
-        "ts-standard": "npx tsc && npx ts-standard",
+        "ts-standard": "npx ts-standard",
         "test": "npx tsc && nyc --reporter=html --reporter=text-summary mocha",
         "coverage": "nyc report --reporter=text-lcov > ./coverage/lcov.info",
         "coveralls": "nyc report --reporter=text-lcov | coveralls && rm -r coverage"

--- a/install/package.json
+++ b/install/package.json
@@ -12,6 +12,7 @@
     "scripts": {
         "start": "npx tsc && node loader.js",
         "lint": "npx tsc && eslint --cache ./nodebb .",
+        "ts-standard": "npx tsc && npx ts-standard",
         "test": "npx tsc && nyc --reporter=html --reporter=text-summary mocha",
         "coverage": "nyc report --reporter=text-lcov > ./coverage/lcov.info",
         "coveralls": "nyc report --reporter=text-lcov | coveralls && rm -r coverage"

--- a/src/controllers/composer.ts
+++ b/src/controllers/composer.ts
@@ -58,7 +58,7 @@ export async function get (req: Request, res: Response<object, Locals>, callback
 
 interface ComposerData {
   uid: number
-  req: Request<object, object, ComposerData>
+  req?: Request<object, object, ComposerData>
   timestamp: number
   content: string
   fromQueue: boolean

--- a/src/languages.ts
+++ b/src/languages.ts
@@ -34,7 +34,7 @@ export async function get (language: string, namespace: string): Promise<Record<
   }
   const data: string = await fs.promises.readFile(pathToLanguageFile, 'utf8')
 
-  const parsed: Record<string, string> = JSON.parse(data) as Record<string, string> || {}
+  const parsed: Record<string, string> = JSON.parse(data) as Record<string, string>
 
   const result: LanguageResult = await plugins.hooks.fire('filter:languages.get', {
     language,
@@ -50,7 +50,7 @@ function isErrnoException (e: unknown): e is NodeJS.ErrnoException {
 
 let codeCache: string[] | null = null
 export async function listCodes (): Promise<string[]> {
-  if (codeCache && (codeCache.length > 0)) {
+  if (codeCache != null && (codeCache.length > 0)) {
     return codeCache
   }
   try {
@@ -69,15 +69,15 @@ export async function listCodes (): Promise<string[]> {
   return []
 }
 
-let listCache: (LanguageData | undefined)[] | null = null
-export async function list (): Promise<(LanguageData | undefined)[] | undefined > {
-  if (listCache && (listCache.length > 0)) {
+let listCache: Array<(LanguageData | undefined)> | null = null
+export async function list (): Promise<Array<(LanguageData | undefined)> | undefined > {
+  if (listCache != null && (listCache.length > 0)) {
     return listCache
   }
 
   const codes = await listCodes()
 
-  let languages: (LanguageData | undefined)[] = []
+  let languages: Array<(LanguageData | undefined)> = []
   languages = await Promise.all(codes.map(async (folder) => {
     try {
       const configPath: string = path.join(languagesPath, folder, 'language.json')
@@ -95,7 +95,7 @@ export async function list (): Promise<(LanguageData | undefined)[] | undefined 
   }))
 
   // filter out invalid ones
-  languages = languages.filter(lang => lang && lang.code && lang.name && lang.dir)
+  languages = languages.filter(lang => lang?.code != null && lang.name != null && lang.dir != null)
 
   listCache = languages
 

--- a/src/languages.ts
+++ b/src/languages.ts
@@ -48,7 +48,7 @@ function isErrnoException (e: unknown): e is NodeJS.ErrnoException {
   return e instanceof Error
 }
 
-let codeCache: string[] = null
+let codeCache: string[] | null = null
 export async function listCodes (): Promise<string[]> {
   if (codeCache && (codeCache.length > 0)) {
     return codeCache
@@ -66,17 +66,18 @@ export async function listCodes (): Promise<string[]> {
       throw err
     }
   }
+  return []
 }
 
-let listCache: LanguageData[] = null
-export async function list (): Promise<LanguageData[]> {
+let listCache: (LanguageData | undefined)[] = [undefined]
+export async function list (): Promise<(LanguageData | undefined)[]> {
   if (listCache && (listCache.length > 0)) {
     return listCache
   }
 
   const codes = await listCodes()
 
-  let languages: LanguageData[] = []
+  let languages: (LanguageData | undefined)[] = []
   languages = await Promise.all(codes.map(async (folder) => {
     try {
       const configPath: string = path.join(languagesPath, folder, 'language.json')

--- a/src/languages.ts
+++ b/src/languages.ts
@@ -69,8 +69,8 @@ export async function listCodes (): Promise<string[]> {
   return []
 }
 
-let listCache: (LanguageData | undefined)[] = [undefined]
-export async function list (): Promise<(LanguageData | undefined)[]> {
+let listCache: (LanguageData | undefined)[] | null = null
+export async function list (): Promise<(LanguageData | undefined)[] | undefined > {
   if (listCache && (listCache.length > 0)) {
     return listCache
   }

--- a/src/social.ts
+++ b/src/social.ts
@@ -10,7 +10,7 @@ import { Network } from './types'
 let postSharing: Network[] | null = null
 
 export async function getPostSharing (): Promise<Network[]> {
-  if (postSharing) {
+  if (postSharing != null) {
     return _.cloneDeep(postSharing)
   }
 
@@ -45,7 +45,7 @@ export async function getPostSharing (): Promise<Network[]> {
 
 export async function getActivePostSharing (): Promise<Network[]> {
   const networks: Network[] = await getPostSharing()
-  return networks.filter(network => network && network.activated)
+  return networks.filter(network => network?.activated)
 }
 
 export async function setActivePostSharingNetworks (networkIDs: string[]): Promise<void> {

--- a/src/user/create.ts
+++ b/src/user/create.ts
@@ -238,7 +238,8 @@ export = function (User: TheUser) {
     minStrength = minStrength ?? (meta.config.minimumPasswordStrength as number)
 
     // Sanity checks: Checks if defined and is string
-    if (!password || !utils.isPasswordValid(password)) {
+    if (password === null || password === undefined ||
+      password.length <= 0 || !(utils.isPasswordValid(password) as boolean)) {
       throw new Error('[[error:invalid-password]]')
     }
 
@@ -268,7 +269,7 @@ export = function (User: TheUser) {
       const exists: boolean = await meta.userOrGroupExists(username)
       /* eslint-enable @typescript-eslint/no-unsafe-assignment, no-await-in-loop */
       if (!exists) {
-        return numTries ? username : null
+        return numTries === 0 ? username : null
       }
       username = `${userData.username} ${numTries.toString(32)}`
       numTries += 1

--- a/src/user/create.ts
+++ b/src/user/create.ts
@@ -171,8 +171,11 @@ export = function (User: TheUser) {
         email: userData.email,
         template: 'welcome',
         // The next line calls a function in a module that has not been updated to TS yet
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access,@typescript-eslint/no-unsafe-call,@typescript-eslint/strict-boolean-expressions
+        /* eslint-disable @typescript-eslint/no-unsafe-member-access,@typescript-eslint/no-unsafe-call */
+        /* eslint-disable @typescript-eslint/strict-boolean-expressions */
         subject: `[[email:welcome-to, ${(meta.config.title as string) || (meta.config.browserTitle as string) || 'NodeBB'}]]`
+        /* eslint-enable @typescript-eslint/no-unsafe-member-access,@typescript-eslint/no-unsafe-call */
+        /* eslint-enable @typescript-eslint/strict-boolean-expressions */
         // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access,@typescript-eslint/no-unsafe-call
       }).catch(err => winston.error(`[user.create] Validation email failed to send\n[emailer.send] ${err.stack as string}`))
     }
@@ -205,8 +208,11 @@ export = function (User: TheUser) {
     try {
       return await create(data)
     } finally {
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access,@typescript-eslint/no-unsafe-call,@typescript-eslint/strict-boolean-expressions
+      /* eslint-disable @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call */
+      /* eslint-disable @typescript-eslint/strict-boolean-expressions */
       await db.deleteObjectFields('locks', [data.username, data.email])
+      /* eslint-enable @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call */
+      /* eslint-enable @typescript-eslint/strict-boolean-expressions */
     }
   }
 

--- a/src/user/delete.ts
+++ b/src/user/delete.ts
@@ -56,7 +56,7 @@ module.exports = function (User: deleting) {
     return await User.deleteAccount(uid)
   }
 
-  async function deletePosts (callerUid: string, uid: string) {
+  async function deletePosts (callerUid: string, uid: string): Promise<void> {
     // The next line calls a function in a module that has not been updated to TS yet
     // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
     await batch.processSortedSet(`uid:${uid}:posts`, async (pids: string) => { await posts.purge(pids, callerUid) }, { alwaysStartAt: 0, batch: 500 })
@@ -68,31 +68,31 @@ module.exports = function (User: deleting) {
     await topics.purge(tid, callerUid)
   }
 
-  async function deleteTopics (callerUid: string, uid: string) {
+  async function deleteTopics (callerUid: string, uid: string): Promise<void> {
     // The next line calls a function in a module that has not been updated to TS yet
     // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
     await batch.processSortedSet(`uid:${uid}:topics`, async (ids: string[]) => {
-      const promises: Promise<void>[] = []
+      const promises: Array<Promise<void>> = []
       for (const tid of ids) {
         promises.push(deleteTopicsHelper(tid, callerUid))
       }
       await Promise.all(promises)
     }, { alwaysStartAt: 0 })
   }
-  async function deleteUploads (callerUid: string, uid: string) {
+  async function deleteUploads (callerUid: string, uid: string): Promise<void> {
     // The next line calls a function in a module that has not been updated to TS yet
     // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
     const uploads: string[] = await db.getSortedSetMembers(`uid:${uid}:uploads`) as string[]
     await User.deleteUpload(callerUid, uid, uploads)
   }
 
-  async function deleteQueuedHelper (id: string) {
+  async function deleteQueuedHelper (id: string): Promise<void> {
     // The next line calls a function in a module that has not been updated to TS yet
     // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
     await posts.removeFromQueue(id)
   }
 
-  async function deleteQueued (uid: string) {
+  async function deleteQueued (uid: string): Promise<void> {
     const deleteIds: string[] = []
     await batch.processSortedSet('post:queue', async (ids: string[]) => {
       // The next line calls a function in a module that has not been updated to TS yet
@@ -103,7 +103,7 @@ module.exports = function (User: deleting) {
       ).map((d: { id: string }) => d.id)
       deleteIds.concat(userQueuedIds)
     }, { batch: 500 })
-    const promises: Promise<void>[] = []
+    const promises: Array<Promise<void>> = []
     for (const id of deleteIds) {
       promises.push(deleteQueuedHelper(id))
     }
@@ -114,6 +114,8 @@ module.exports = function (User: deleting) {
     if (parseInt(uid, 10) <= 0) {
       throw new Error('[[error:invalid-uid]]')
     }
+    // Disable to pass previously written unit tests
+    // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
     if (deletesInProgress[uid]) {
       throw new Error('[[error:already-deleting]]')
     }
@@ -122,10 +124,11 @@ module.exports = function (User: deleting) {
     await deleteTopics(callerUid, uid)
     await deleteUploads(callerUid, uid)
     await deleteQueued(uid)
+    // eslint-disable-next-line @typescript-eslint/no-dynamic-delete
     delete deletesInProgress[uid]
   }
 
-  async function removeFromSortedSets (uid: string) {
+  async function removeFromSortedSets (uid: string): Promise<void> {
     // The next line calls a function in a module that has not been updated to TS yet
     // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
     await db.sortedSetsRemove([
@@ -143,12 +146,12 @@ module.exports = function (User: deleting) {
     ], uid)
   }
 
-  async function deleteVotesHelper (pid: string, uid: string) {
+  async function deleteVotesHelper (pid: string, uid: string): Promise<void> {
     // The next line calls a function in a module that has not been updated to TS yet
     // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
     await posts.unvote(pid, uid)
   }
-  async function deleteVotes (uid: string) {
+  async function deleteVotes (uid: string): Promise<void> {
     const [upvotedPids, downvotedPids]: [string[], string[]] = await Promise.all([
       // The next line calls a function in a module that has not been updated to TS yet
       // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
@@ -159,14 +162,14 @@ module.exports = function (User: deleting) {
     ])
     const pids = _.uniq(upvotedPids.concat(downvotedPids).filter(Boolean))
 
-    const promises: Promise<void>[] = []
+    const promises: Array<Promise<void>> = []
     for (const pid of pids) {
       promises.push(deleteVotesHelper(pid, uid))
     }
     await Promise.all(promises)
   }
 
-  async function deleteChats (uid: string) {
+  async function deleteChats (uid: string): Promise<void> {
     // The next line calls a function in a module that has not been updated to TS yet
     // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
     const roomIds: string[] = await db.getSortedSetRange(`uid:${uid}:chat:rooms`, 0, -1) as string[]
@@ -179,7 +182,7 @@ module.exports = function (User: deleting) {
     ])
   }
 
-  async function deleteUserIps (uid: string) {
+  async function deleteUserIps (uid: string): Promise<void> {
     // The next line calls a function in a module that has not been updated to TS yet
     // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
     const ips: string[] = await db.getSortedSetRange(`uid:${uid}:ip`, 0, -1) as string[]
@@ -191,7 +194,7 @@ module.exports = function (User: deleting) {
     await db.delete(`uid:${uid}:ip`)
   }
 
-  async function deleteUserFromFollowers (uid: string) {
+  async function deleteUserFromFollowers (uid: string): Promise<void> {
     const [followers, following]: [string[], string[]] = await Promise.all([
       // The next line calls a function in a module that has not been updated to TS yet
       // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
@@ -200,18 +203,17 @@ module.exports = function (User: deleting) {
       // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
       db.getSortedSetRange(`following:${uid}`, 0, -1) as Promise<[string]>
     ])
-    async function updateCountHelper (name: string, uid: string, fieldName: string) {
-      // The next line calls a function in a module that has not been updated to TS yet
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
-      // The next line calls a function in a module that has not been updated to TS yet
+    async function updateCountHelper (name: string, uid: string, fieldName: string): Promise<void> {
+      // The next lines call function(s) in a module that have not been updated to TS yet
       /* eslint-disable @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access */
       const count: string = await db.sortedSetCard(name + uid) as string
-      const count_: number = parseInt(count, 10) || 0
+      const parsedint: number = parseInt(count, 10)
+      const count_: number = parsedint ?? 0
       await db.setObjectField(`user:${uid}`, fieldName, count_)
       /* eslint-enable @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access */
     }
-    async function updateCount (uids: string[], name: string, fieldName: string) {
-      const promises: Promise<void>[] = []
+    async function updateCount (uids: string[], name: string, fieldName: string): Promise<void> {
+      const promises: Array<Promise<void>> = []
       for (const uid of uids) {
         promises.push(updateCountHelper(name, uid, fieldName))
       }
@@ -230,7 +232,7 @@ module.exports = function (User: deleting) {
     ])
   }
 
-  async function deleteImages (uid: string) {
+  async function deleteImages (uid: string): Promise<void> {
     // The next line calls a function in a module that has not been updated to TS yet
     // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
     const folder = path.join(nconf.get('upload_path') as string, 'profile')
@@ -251,10 +253,12 @@ module.exports = function (User: deleting) {
     // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
     const userData: UserData = await db.getObject(`user:${uid}`) as UserData
 
-    if (!userData || !userData.username) {
+    /* eslint-disable @typescript-eslint/strict-boolean-expressions,@typescript-eslint/no-dynamic-delete */
+    if (!userData?.username) {
       delete deletesInProgress[uid]
       throw new Error('[[error:no-user]]')
     }
+    /* eslint-enable @typescript-eslint/strict-boolean-expressions,@typescript-eslint/no-dynamic-delete */
 
     await plugins.hooks.fire('static:user.delete', { uid, userData })
     await deleteVotes(uid)
@@ -289,12 +293,12 @@ module.exports = function (User: deleting) {
       ['fullname:uid', userData.fullname],
       ['accounttype:uid', userData.accounttype]
     ]
-    if (userData.email) {
+    if (userData.email !== null && userData.email !== undefined) {
       bulkRemove.push(['email:uid', userData.email.toLowerCase()])
       bulkRemove.push(['email:sorted', `${userData.email.toLowerCase()}:${uid}`])
     }
 
-    if (userData.fullname) {
+    if (userData.fullname !== null && userData.fullname !== undefined) {
       bulkRemove.push(['fullname:sorted', `${userData.fullname.toLowerCase()}:${uid}`])
     }
 
@@ -325,6 +329,8 @@ module.exports = function (User: deleting) {
     // The next line calls a function in a module that has not been updated to TS yet
     // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
     await db.deleteAll([`followers:${uid}`, `following:${uid}`, `user:${uid}`])
+    // Ignore dynamic delete warning
+    // eslint-disable-next-line @typescript-eslint/no-dynamic-delete
     delete deletesInProgress[uid]
     return userData
   }

--- a/src/user/delete.ts
+++ b/src/user/delete.ts
@@ -31,17 +31,17 @@ interface UserData {
 interface deleting {
   delete?: (callerUid: string, uid: string) =>
   Promise<UserData>
-  deleteContent?: (arg0: string, arg1: string) =>
+  deleteContent: (arg0: string, arg1: string) =>
   Promise<void>
-  deleteAccount?: (arg0: string) =>
+  deleteAccount: (arg0: string) =>
   Promise<UserData>
-  deleteUpload?: (arg0: string, arg1: string, arg2: string[]) =>
+  deleteUpload: (arg0: string, arg1: string, arg2: string[]) =>
   Promise<UserData>
   auth: {
-    revokeAllSessions?: (arg0: string) => Promise<void>
+    revokeAllSessions: (arg0: string) => Promise<void>
   }
   reset: {
-    cleanByUid?: (arg0: string) => Promise<void>
+    cleanByUid: (arg0: string) => Promise<void>
   }
 }
 
@@ -62,7 +62,7 @@ module.exports = function (User: deleting) {
     await batch.processSortedSet(`uid:${uid}:posts`, async (pids: string) => { await posts.purge(pids, callerUid) }, { alwaysStartAt: 0, batch: 500 })
   }
 
-  async function deleteTopicsHelper (tid: string, callerUid: string) {
+  async function deleteTopicsHelper (tid: string, callerUid: string): Promise<void> {
     // The next line calls a function in a module that has not been updated to TS yet
     // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
     await topics.purge(tid, callerUid)
@@ -72,7 +72,7 @@ module.exports = function (User: deleting) {
     // The next line calls a function in a module that has not been updated to TS yet
     // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
     await batch.processSortedSet(`uid:${uid}:topics`, async (ids: string[]) => {
-      const promises = []
+      const promises: Promise<void>[] = []
       for (const tid of ids) {
         promises.push(deleteTopicsHelper(tid, callerUid))
       }
@@ -103,14 +103,14 @@ module.exports = function (User: deleting) {
       ).map((d: { id: string }) => d.id)
       deleteIds.concat(userQueuedIds)
     }, { batch: 500 })
-    const promises = []
+    const promises: Promise<void>[] = []
     for (const id of deleteIds) {
       promises.push(deleteQueuedHelper(id))
     }
     await Promise.all(promises)
   }
 
-  User.deleteContent = async function (callerUid, uid) {
+  User.deleteContent = async function (callerUid, uid): Promise<void> {
     if (parseInt(uid, 10) <= 0) {
       throw new Error('[[error:invalid-uid]]')
     }
@@ -124,6 +124,7 @@ module.exports = function (User: deleting) {
     await deleteQueued(uid)
     delete deletesInProgress[uid]
   }
+
   async function removeFromSortedSets (uid: string) {
     // The next line calls a function in a module that has not been updated to TS yet
     // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
@@ -158,7 +159,7 @@ module.exports = function (User: deleting) {
     ])
     const pids = _.uniq(upvotedPids.concat(downvotedPids).filter(Boolean))
 
-    const promises = []
+    const promises: Promise<void>[] = []
     for (const pid of pids) {
       promises.push(deleteVotesHelper(pid, uid))
     }
@@ -210,7 +211,7 @@ module.exports = function (User: deleting) {
       /* eslint-enable @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access */
     }
     async function updateCount (uids: string[], name: string, fieldName: string) {
-      const promises = []
+      const promises: Promise<void>[] = []
       for (const uid of uids) {
         promises.push(updateCountHelper(name, uid, fieldName))
       }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,6 +5,7 @@
     "module": "commonjs",
     "moduleResolution": "node",
     "esModuleInterop": true,
+    "strictNullChecks": true,
   },
   "include": [
     "public/src/**/*",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,6 @@
     "module": "commonjs",
     "moduleResolution": "node",
     "esModuleInterop": true,
-    "strictNullChecks": true,
   },
   "include": [
     "public/src/**/*",


### PR DESCRIPTION
[BACKEND]

Fixed the following files to resolve outstanding errors from `ts-standard` tool:
- composer.ts
- languages.ts
- src/types/error.ts
- src/types/flag.ts
- src/types/user.ts
- src/user/create.ts

Currently resolving `npm run lint` errors resulting from turning on `strictNullChecks`.